### PR TITLE
Missing `.git` of a submodule is now a soft error

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -3,8 +3,8 @@
 
 macro(check_submodule_git dir)
 if (NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${dir}/.git")
-    message(SEND_ERROR
-    "\n=== ERROR ===\n"
+    message(WARNING
+    "\n=== WARNING ===\n"
     "Looks like you've forgot to clone the dependencies,"
     " as `${CMAKE_CURRENT_SOURCE_DIR}/${dir}` is not a Git repository.\n"
     "Don't worry, just run `git submodule update --init` to fix this.\n\n")


### PR DESCRIPTION
If someone tries to build by using only the source files without Git,
then the submodules probably aren't Git repositories either.
