### PR TITLE
Fix compile errors of the previous merge

### DIFF
--- a/es-app/src/scrapers/GamesDBShaScraper.cpp
+++ b/es-app/src/scrapers/GamesDBShaScraper.cpp
@@ -48,7 +48,7 @@ boost::filesystem::path get_or_fetch_hash_file()
 		LOG(LogError) << "HTTP request error - " << myRequest.getErrorMsg();
 		return boost::filesystem::path ("");
 	}
-	std::ofstream ofile (hash_path.c_str());
+	std::ofstream ofile (hash_path.string());
 	ofile << myRequest.getContent();
 	ofile.close();
 	return hash_path;
@@ -62,7 +62,7 @@ void init_hash_maps ()
 	{
 		return;
 	}
-	std::ifstream file (hash_path.c_str());
+	std::ifstream file (hash_path.string());
 	if (!file)
 	{
 		return;

--- a/es-app/src/scrapers/ROMHasher.cpp
+++ b/es-app/src/scrapers/ROMHasher.cpp
@@ -245,7 +245,7 @@ std::string hash_rom(HashFunc * hf, boost::filesystem::path path)
 {
 	std::streampos size;
 	boost::filesystem::path ext;
-	std::ifstream file (path.c_str(), std::ios::binary | std::ios::ate);
+	std::ifstream file (path.string(), std::ios::binary | std::ios::ate);
 	if (file.is_open())
 	{
 		size = file.tellg();


### PR DESCRIPTION
Apparently certain compilers don't accept `boost`'s `path::c_str()`.
