### PR TITLE
Ignore compiled `res2h` executable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ data/converted/*.cpp
 
 # Compiled executable
 emulationstation
+res2h
 
 # build directory
 build


### PR DESCRIPTION
Since `res2h` is an included dependency, its compiled executable is also placed in the project's root.
