### PR TITLE
Add custom configuration directory support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,11 @@ if(DEFINED BCMHOST)
     add_definitions(-D_RPI_)
 endif()
 
+option(XDG_ON_OSX "Try to store settings in XDG_CONFIG_HOME on OSX" OFF)
+if(XDG_ON_OSX)
+    add_definitions(-DUSE_XDG_OSX)
+endif()
+
 #-------------------------------------------------------------------------------
 
 # Require C++11

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ Configuration files are stored in `$CONFIG_DIR`, which is by default
 - on Linux: `$XDG_CONFIG_HOME/emulationstation/` which usually defaults to `~/.config/emulationstation/`
 - on OSX: `~/Library/Application Support/org.emulationstation.EmulationStation/` by default, or the same as Linux if EmulationStation is build with the `XDG_ON_OSX` CMake flag.
 
+Alternatively you can specify `$CONFIG_DIR` through the `--config-dir [path]` command line option.
+
 **es_systems.cfg:**
 
 When first run, an example systems configuration file will be created at `$CONFIG_DIR/es_systems.cfg`. This example has some comments explaining how to write the configuration file. See the "Writing an es_systems.cfg" section for more information.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ cmake .
 make
 ```
 
-- If your problem still isn't gone, the best way to report a bug is to post an issue on GitHub. Try to post the simplest steps possible to reproduce the bug. Include files you think might be related (except for ROMs, of course). If you haven't re-run ES since the crash, the log file `~/.emulationstation/es_log.txt` is also helpful.
+- If your problem still isn't gone, the best way to report a bug is to post an issue on GitHub. Try to post the simplest steps possible to reproduce the bug. Include files you think might be related (except for ROMs, of course). If you haven't re-run ES since the crash, the log file `$CONFIG_DIR/es_log.txt` is also helpful.
 
 Building
 ========
@@ -79,12 +79,19 @@ Complete Raspberry Pi build instructions at [emulationstation.org](http://emulat
 Configuring
 ===========
 
-**~/.emulationstation/es_systems.cfg:**
-When first run, an example systems configuration file will be created at `~/.emulationstation/es_systems.cfg`.  `~` is `$HOME` on Linux, and `%HOMEPATH%` on Windows.  This example has some comments explaining how to write the configuration file. See the "Writing an es_systems.cfg" section for more information.
+Configuration files are stored in `$CONFIG_DIR`, which is by default
+
+- on Windows: `My Documents/EmulationStation/`
+- on Linux: `$XDG_CONFIG_HOME/emulationstation/` which usually defaults to `~/.config/emulationstation/`
+- on OSX: `~/Library/Application Support/org.emulationstation.EmulationStation/` by default, or the same as Linux if EmulationStation is build with the `XDG_ON_OSX` CMake flag.
+
+**es_systems.cfg:**
+
+When first run, an example systems configuration file will be created at `$CONFIG_DIR/es_systems.cfg`. This example has some comments explaining how to write the configuration file. See the "Writing an es_systems.cfg" section for more information.
 
 **Keep in mind you'll have to set up your emulator separately from EmulationStation!**
 
-**~/.emulationstation/es_input.cfg:**
+**es_input.cfg:**
 When you first start EmulationStation, you will be prompted to configure an input device. The process is thus:
 
 1. Hold a button on the device you want to configure.  This includes the keyboard.
@@ -95,11 +102,11 @@ When you first start EmulationStation, you will be prompted to configure an inpu
 
 4. Choose "SAVE" to save this device and close the input configuration screen.
 
-The new configuration will be added to the `~/.emulationstation/es_input.cfg` file.
+The new configuration will be added to the `es_input.cfg` file.
 
 **Both new and old devices can be (re)configured at any time by pressing the Start button and choosing "CONFIGURE INPUT".**  From here, you may unplug the device you used to open the menu and plug in a new one, if necessary.  New devices will be appended to the existing input configuration file, so your old devices will remain configured.
 
-**If your controller stops working, you can delete the `~/.emulationstation/es_input.cfg` file to make the input configuration screen re-appear on next run.**
+**If your controller stops working, you can delete the `es_input.cfg` file to make the input configuration screen re-appear on next run.**
 
 
 You can use `--help` or `-h` to view a list of command-line options. Briefly outlined here:
@@ -126,7 +133,7 @@ Complete configuration instructions at [emulationstation.org](http://emulationst
 The `es_systems.cfg` file contains the system configuration data for EmulationStation, written in XML.  This tells EmulationStation what systems you have, what platform they correspond to (for scraping), and where the games are located.
 
 ES will check two places for an es_systems.cfg file, in the following order, stopping after it finds one that works:
-* `~/.emulationstation/es_systems.cfg`
+* `$CONFIG_DIR/es_systems.cfg`
 * `/etc/emulationstation/es_systems.cfg`
 
 The order EmulationStation displays systems reflects the order you define them in.

--- a/es-app/src/SystemManager.cpp
+++ b/es-app/src/SystemManager.cpp
@@ -21,7 +21,7 @@ SystemManager* SystemManager::getInstance()
 
 std::string SystemManager::getDatabasePath()
 {
-	return getHomePath() + "/.emulationstation/gamelist.db";
+	return getConfigDirectory() + "/gamelist.db";
 }
 
 SystemManager::SystemManager() : mDatabase(getDatabasePath())
@@ -199,7 +199,7 @@ void SystemManager::writeExampleConfig(const fs::path& path)
 
 fs::path SystemManager::getConfigPath(bool forWrite)
 {
-	fs::path path = getHomePath() + "/.emulationstation/es_systems.cfg";
+	fs::path path = getConfigDirectory() + "/es_systems.cfg";
 	if(forWrite || fs::exists(path))
 		return path.generic_string();
 
@@ -268,7 +268,7 @@ fs::path SystemManager::getGamelistXMLPath(const SystemData* sys, bool forWrite)
 	if(fs::exists(filePath))
 		return filePath;
 
-	filePath = getHomePath() + "/.emulationstation/gamelists/" + sys->getName() + "/gamelist.xml";
+	filePath = getConfigDirectory() + "/gamelists/" + sys->getName() + "/gamelist.xml";
 	if(forWrite) // make sure the directory exists if we're going to write to it, or crashes will happen
 		fs::create_directories(filePath.parent_path());
 	if(forWrite || fs::exists(filePath))

--- a/es-app/src/main.cpp
+++ b/es-app/src/main.cpp
@@ -103,12 +103,11 @@ bool parseArgs(int argc, char* argv[], unsigned int* width, unsigned int* height
 bool verifyHomeFolderExists()
 {
 	// make sure the config directory exists
-	std::string home = getHomePath();
-	std::string configDir = home + "/.emulationstation";
+	std::string configDir = getConfigDirectory();
 	if(!fs::exists(configDir))
 	{
 		std::cout << "Creating config directory \"" << configDir << "\"\n";
-		fs::create_directory(configDir);
+		fs::create_directories(configDir);
 		if(!fs::exists(configDir))
 		{
 			std::cerr << "Config directory could not be created!\n";

--- a/es-app/src/main.cpp
+++ b/es-app/src/main.cpp
@@ -54,6 +54,17 @@ bool parseArgs(int argc, char* argv[], unsigned int* width, unsigned int* height
 		}else if(strcmp(argv[i], "--no-exit") == 0)
 		{
 			Settings::getInstance()->setBool("ShowExit", false);
+		}else if(strcmp(argv[i], "--config-dir") == 0)
+		{
+			if(i >= argc - 1)
+			{
+				std::cerr << "No config directory supplied.";
+				return false;
+			}
+
+			i++;
+			auto configDir = std::string(argv[i]);
+			Settings::getInstance()->setString("ConfigDirectory", configDir);
 		}else if(strcmp(argv[i], "--debug") == 0)
 		{
 			Settings::getInstance()->setBool("Debug", true);
@@ -87,6 +98,7 @@ bool parseArgs(int argc, char* argv[], unsigned int* width, unsigned int* height
 				"--ignore-gamelist		ignore the gamelist (useful for troubleshooting)\n"
 				"--draw-framerate		display the framerate\n"
 				"--no-exit			don't show the exit option in the menu\n"
+				"--config-dir [path]		use path as config directory\n"
 				"--debug				more logging, show console on Windows\n"
 				"--scrape			scrape using command line interface\n"
 				"--windowed			not fullscreen, should be used with --resolution\n"
@@ -202,7 +214,7 @@ int main(int argc, char* argv[])
 	}
 #endif
 
-	// if ~/.emulationstation doesn't exist and cannot be created, bail
+	// if the config dir doesn't exist and cannot be created, bail
 	if(!verifyHomeFolderExists())
 		return 1;
 
@@ -231,6 +243,9 @@ int main(int argc, char* argv[])
 	LOG(LogInfo) << " ARB_texture_non_power_of_two: " << (glExts.find("ARB_texture_non_power_of_two") != std::string::npos ? "ok" : "MISSING");
 
 	window.renderLoadingScreen();
+
+	// try to load the settings file, or use defaults
+	Settings::getInstance()->loadFile();
 
 	const char* errorMsg = NULL;
 	if(!loadSystemConfigFile(&errorMsg))

--- a/es-app/src/scrapers/GamesDBShaScraper.cpp
+++ b/es-app/src/scrapers/GamesDBShaScraper.cpp
@@ -19,8 +19,7 @@ std::map<std::string, std::string> hash_to_name;
 
 boost::filesystem::path get_hash_path()
 {
-	std::string home = getHomePath();
-	boost::filesystem::path hash_path = home + "/.emulationstation/rom_hashes";
+	boost::filesystem::path hash_path = getConfigDirectory() + "/rom_hashes";
 	boost::filesystem::create_directories(hash_path);
 	hash_path = hash_path / "hash.tsv";
 	return hash_path;

--- a/es-app/src/scrapers/Scraper.cpp
+++ b/es-app/src/scrapers/Scraper.cpp
@@ -274,7 +274,7 @@ std::string getSaveAsPath(const ScraperSearchParams& params, const std::string& 
 	const std::string subdirectory = params.system->getName();
 	const std::string name = params.game.getPath().stem().generic_string() + "-" + suffix;
 
-	std::string path = getHomePath() + "/.emulationstation/downloaded_images/";
+	std::string path = getConfigDirectory() + "/downloaded_images/";
 
 	if(!boost::filesystem::exists(path))
 		boost::filesystem::create_directory(path);

--- a/es-core/src/InputManager.cpp
+++ b/es-core/src/InputManager.cpp
@@ -331,9 +331,7 @@ void InputManager::writeDeviceConfig(InputConfig* config)
 
 std::string InputManager::getConfigPath()
 {
-	std::string path = getHomePath();
-	path += "/.emulationstation/es_input.cfg";
-	return path;
+	return getConfigDirectory() + "/es_input.cfg";
 }
 
 bool InputManager::initialized() const

--- a/es-core/src/Log.cpp
+++ b/es-core/src/Log.cpp
@@ -14,8 +14,7 @@ LogLevel Log::getReportingLevel()
 
 std::string Log::getLogPath()
 {
-	std::string home = getHomePath();
-	return home + "/.emulationstation/es_log.txt";
+	return getConfigDirectory() + "/es_log.txt";
 }
 
 void Log::setReportingLevel(LogLevel level)

--- a/es-core/src/Settings.cpp
+++ b/es-core/src/Settings.cpp
@@ -110,7 +110,7 @@ void saveMap(pugi::xml_document& doc, std::map<std::string, std::time_t>& map, c
 
 void Settings::saveFile()
 {
-	const std::string path = getHomePath() + "/.emulationstation/es_settings.cfg";
+	const std::string path = getConfigDirectory() + "/es_settings.cfg";
 
 	pugi::xml_document doc;
 
@@ -132,7 +132,7 @@ void Settings::saveFile()
 
 void Settings::loadFile()
 {
-	const std::string path = getHomePath() + "/.emulationstation/es_settings.cfg";
+	const std::string path = getConfigDirectory() + "/es_settings.cfg";
 
 	if(!boost::filesystem::exists(path))
 		return;

--- a/es-core/src/Settings.cpp
+++ b/es-core/src/Settings.cpp
@@ -19,12 +19,12 @@ std::vector<const char*> settings_dont_save = boost::assign::list_of
 	("Windowed")
 	("VSync")
 	("HideConsole")
+	("ConfigDirectory")
 	("IgnoreGamelist");
 
 Settings::Settings()
 {
 	setDefaults();
-	loadFile();
 }
 
 Settings* Settings::getInstance()
@@ -74,6 +74,7 @@ void Settings::setDefaults()
 	mStringMap["ThemeSet"] = "";
 	mStringMap["ScreenSaverBehavior"] = "dim";
 	mStringMap["Scraper"] = "TheGamesDB";
+	mStringMap["ConfigDirectory"] = "";
 
 	mTimeMap["LastXMLImportTime"] = (std::time_t)0;
 }

--- a/es-core/src/ThemeData.cpp
+++ b/es-core/src/ThemeData.cpp
@@ -362,7 +362,7 @@ const std::shared_ptr<ThemeData>& ThemeData::getDefault()
 	{
 		theme = std::shared_ptr<ThemeData>(new ThemeData());
 
-		const std::string path = getHomePath() + "/.emulationstation/es_theme_default.xml";
+		const std::string path = getConfigDirectory() + "/es_theme_default.xml";
 		if(fs::exists(path))
 		{
 			try
@@ -432,7 +432,7 @@ std::map<std::string, ThemeSet> ThemeData::getThemeSets()
 	static const size_t pathCount = 2;
 	fs::path paths[pathCount] = {
 		"/etc/emulationstation/themes",
-		getHomePath() + "/.emulationstation/themes"
+		getConfigDirectory() + "/themes"
 	};
 
 	fs::directory_iterator end;

--- a/es-core/src/platform.cpp
+++ b/es-core/src/platform.cpp
@@ -5,6 +5,8 @@
 
 #ifdef WIN32
 #include <codecvt>
+#include <shlobj.h>
+#include <windows.h>
 #endif
 
 std::string getHomePath()
@@ -37,6 +39,31 @@ std::string getHomePath()
 	// convert path to generic directory seperators
 	boost::filesystem::path genericPath(homePath);
 	return genericPath.generic_string();
+}
+
+std::string getConfigDirectory()
+{
+	boost::filesystem::path path;
+#ifdef _WIN32
+	CHAR my_documents[MAX_PATH];
+	SHGetFolderPath(NULL, CSIDL_PERSONAL, NULL, SHGFP_TYPE_CURRENT, my_documents);
+	path = boost::filesystem::path(my_documents) / "EmulationStation";
+#elif __APPLE__ && !defined(USE_XDG_OSX)
+	const char* homePath = getenv("HOME");
+	path = boost::filesystem::path(homePath);
+	path /= "Library" / "Application Support" / "org.emulationstation.EmulationStation";
+#else
+	const char* envXdgConfig = getenv("XDG_CONFIG_HOME");
+	if(envXdgConfig) {
+		path = boost::filesystem::path(envXdgConfig);
+	} else {
+		const char* homePath = getenv("HOME");
+		path = boost::filesystem::path(homePath);
+		path /= boost::filesystem::path(".config");
+	}
+	path /= boost::filesystem::path("emulationstation");
+#endif
+	return path.generic_string();
 }
 
 int runShutdownCommand()

--- a/es-core/src/platform.cpp
+++ b/es-core/src/platform.cpp
@@ -1,4 +1,5 @@
 #include "platform.h"
+#include "Settings.h"
 #include <stdlib.h>
 #include <boost/filesystem.hpp>
 #include <iostream>
@@ -43,6 +44,9 @@ std::string getHomePath()
 
 std::string getConfigDirectory()
 {
+	if (!Settings::getInstance()->getString("ConfigDirectory").empty())
+		return Settings::getInstance()->getString("ConfigDirectory");
+
 	boost::filesystem::path path;
 #ifdef _WIN32
 	CHAR my_documents[MAX_PATH];
@@ -63,7 +67,9 @@ std::string getConfigDirectory()
 	}
 	path /= boost::filesystem::path("emulationstation");
 #endif
-	return path.generic_string();
+	auto final_path = path.generic_string();
+	Settings::getInstance()->setString("ConfigDirectory", final_path);
+	return final_path;
 }
 
 int runShutdownCommand()

--- a/es-core/src/platform.h
+++ b/es-core/src/platform.h
@@ -18,6 +18,7 @@
 #include <string>
 
 std::string getHomePath();
+std::string getConfigDirectory();
 
 int runShutdownCommand(); // shut down the system (returns 0 if successful)
 int runRestartCommand(); // restart the system (returns 0 if successful)


### PR DESCRIPTION
This PR moves the configuration directory from `~/.emulationstation` to the standard config locations (see README). A custom location can be set with the new `--config-dir` command line option.

Based on the original patches by [Herdinger](https://github.com/Herdinger), but heavily edited on some places.
