### PR TITLE
Hide mouse cursor before window creation

### DIFF
--- a/es-core/src/Renderer_init_sdlgl.cpp
+++ b/es-core/src/Renderer_init_sdlgl.cpp
@@ -36,6 +36,9 @@ namespace Renderer
 			return false;
 		}
 
+		//hide mouse cursor early
+		initialCursorState = SDL_ShowCursor(0) == 1;
+
 		SDL_GL_SetAttribute(SDL_GL_RED_SIZE, 8);
 		SDL_GL_SetAttribute(SDL_GL_GREEN_SIZE, 8);
 		SDL_GL_SetAttribute(SDL_GL_BLUE_SIZE, 8);
@@ -107,9 +110,6 @@ namespace Renderer
 			if(SDL_GL_SetSwapInterval(-1) != 0 && SDL_GL_SetSwapInterval(1) != 0)
 				LOG(LogWarning) << "Tried to enable vsync, but failed! (" << SDL_GetError() << ")";
 		}
-
-		//hide mouse cursor
-		initialCursorState = SDL_ShowCursor(0) == 1;
 
 		return true;
 	}


### PR DESCRIPTION
> the mouse cursor initially was hidden after the call to SDL_CreateWindow. This will cause a minimal flicker on startup, because it's shown for a short period of time. The cursor is now disabled before the window creation.

Source: Aloshi/EmulationStation#517
