### PR TITLE
Add symlink support

### DIFF
--- a/es-core/src/Util.cpp
+++ b/es-core/src/Util.cpp
@@ -103,7 +103,8 @@ fs::path removeCommonPath(const fs::path& path, const fs::path& relativeTo, bool
 		return path;
 	}
 
-	fs::path p = fs::canonical(path);
+	// if it's a symlink we don't want to apply fs::canonical on it, otherwise we'll lose the current parent_path
+	fs::path p = (fs::is_symlink(path) ? fs::canonical(path.parent_path()) / path.filename() : fs::canonical(path));
 	fs::path r = fs::canonical(relativeTo);
 
 	if(p.root_path() != r.root_path())


### PR DESCRIPTION
> The problem is that removeCommonPath doesn't work with symlinks 'cause fs::canonical returns the path of the original file instead of the symlink's, and relativeTo doesn't necessarily have to match the former, it's ment to match the latter. This causes that the scraped metadata doesn't work. We can avoid this by applying fs::canonical just to the parent path and then append the filename when the file is a symlink.

Source: Aloshi/EmulationStation#430
